### PR TITLE
Disabled grid column hiding when dragged outside grid

### DIFF
--- a/src/components/Grid/QuotesDisplay.js
+++ b/src/components/Grid/QuotesDisplay.js
@@ -80,6 +80,7 @@ class QuotesDisplay extends Component {
             <AgGridReact
               columnDefs={this.state.columnDefs}
               rowData={this.state.rowData}
+              suppressDragLeaveHidesColumns={true}
               gridOptions={gridOptions}
               onFirstDataRendered={this.onFirstDataRendered.bind(this)}
               >


### PR DESCRIPTION
Columns were hid from grid when they were dragged outside. Disabled that feature